### PR TITLE
feat: add destroy methods and fix benchmark abort error

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -69,6 +69,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, build]
+    permissions:
+      id-token: write
     steps:
       - name: Check out repo
         uses: actions/checkout@v5
@@ -84,5 +86,4 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ dist/
 !/.env.dev
 /.idea/
 /.tap/
+/.claude/

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -6,33 +6,41 @@ const { Signer } = require("../dist/cjs/index.js");
 const { Sha256 } = require("@aws-crypto/sha256-js");
 const { HttpRequest } = require("@smithy/protocol-http");
 const { SignatureV4 } = require("@smithy/signature-v4");
-const signerfgiova = new Signer();
+let signerfgiova;
 const suite = new Benchmark.Suite("Signer Performance Test", {
 	minSamples: 10,
 	onCycle: (e) => {
 		const benchmark = e.target;
 		console.log(benchmark.toString());
 	},
-	onComplete: async (e) => {
+	onComplete: (e) => {
 		const suite = e.currentTarget;
 		const fastestOption = suite.filter("fastest").map("name");
 		console.log(`The fastest option is ${fastestOption}`);
-		await signerfgiova.destroy();
 		process.exit(0);
 	},
 });
-suite.add("AWS Signature @fgiova", async () => {
-	const service = randomUUID();
-	const requestData = {
-		method: "POST",
-		path: "/",
-		headers: {
-			host: `${service}.us-bar-1.amazonaws.com`,
+suite.add(
+	"AWS Signature @fgiova",
+	async () => {
+		const service = randomUUID();
+		const requestData = {
+			method: "POST",
+			path: "/",
+			headers: {
+				host: `${service}.us-bar-1.amazonaws.com`,
+			},
+		};
+		const date = new Date("2000-01-01T00:00:00.000Z");
+		return signerfgiova.request(requestData, service, "us-bar-1", date);
+	},
+	{
+		onComplete: () => {},
+		onStart: async () => {
+			signerfgiova = new Signer();
 		},
-	};
-	const date = new Date("2000-01-01T00:00:00.000Z");
-	return signerfgiova.request(requestData, service, "us-bar-1", date);
-});
+	},
+);
 suite.add("AWS Signature @aws-sdk", async () => {
 	const signerInit = {
 		service: randomUUID(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "@fgiova/aws-signature",
-	"version": "3.1.2",
+	"version": "3.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@fgiova/aws-signature",
-			"version": "3.1.2",
+			"version": "3.2.0",
 			"license": "MIT",
 			"dependencies": {
-				"@sinclair/typebox": "^0.34.41",
-				"env-schema": "^6.0.1",
-				"lru-cache": "^11.0.2",
-				"piscina": "^5.1.3"
+				"@sinclair/typebox": "^0.34.48",
+				"env-schema": "^7.0.0",
+				"lru-cache": "^11.2.5",
+				"piscina": "^5.1.4"
 			},
 			"devDependencies": {
 				"@aws-crypto/sha256-js": "^5.2.0",
@@ -20,8 +20,8 @@
 				"@fgiova/cjs-esm-ts-builder": "^1.2.0",
 				"@semantic-release/changelog": "^6.0.3",
 				"@semantic-release/git": "^10.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/signature-v4": "^5.0.1",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/signature-v4": "^5.3.8",
 				"@tsconfig/node20": "^20.1.4",
 				"@types/node": "^20.17.23",
 				"benchmark": "^2.1.4",
@@ -1987,9 +1987,9 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.34.41",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
-			"integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+			"version": "0.34.48",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
 			"license": "MIT"
 		},
 		"node_modules/@sindresorhus/is": {
@@ -2029,12 +2029,13 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-			"integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+			"version": "5.3.8",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
+			"integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.12.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2042,10 +2043,11 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http/node_modules/@smithy/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+			"integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2054,18 +2056,19 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-			"integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+			"version": "5.3.8",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
+			"integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-hex-encoding": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-uri-escape": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
+				"@smithy/is-array-buffer": "^4.2.0",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-hex-encoding": "^4.2.0",
+				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/util-uri-escape": "^4.2.0",
+				"@smithy/util-utf8": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2073,10 +2076,11 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4/node_modules/@smithy/is-array-buffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-			"integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+			"integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2085,10 +2089,11 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+			"integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2097,12 +2102,13 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4/node_modules/@smithy/util-buffer-from": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-			"integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+			"integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.0.0",
+				"@smithy/is-array-buffer": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2110,12 +2116,13 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-			"integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+			"integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.0.0",
+				"@smithy/util-buffer-from": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2148,10 +2155,11 @@
 			}
 		},
 		"node_modules/@smithy/util-hex-encoding": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-			"integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+			"integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2160,12 +2168,13 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-			"integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
+			"integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.12.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2173,10 +2182,11 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+			"integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2185,10 +2195,11 @@
 			}
 		},
 		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-			"integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+			"integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -4036,25 +4047,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/dotenv": {
-			"version": "16.4.7",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-			"integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
-			}
-		},
-		"node_modules/dotenv-expand": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
-			"integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/duplexer2": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -4249,9 +4241,9 @@
 			}
 		},
 		"node_modules/env-schema": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/env-schema/-/env-schema-6.0.1.tgz",
-			"integrity": "sha512-WRD40Q25pP4NUbI3g3CNU5PPzcaiX7YYcPwiCZlfR4qGsKmTlckRixgHww0/fOXiXSNKA87pwshzq0ULTK/48A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/env-schema/-/env-schema-7.0.0.tgz",
+			"integrity": "sha512-b8rdAwdFpekDxNAUNuT6KbV/QEX/pTBs0gjehEPmBUUteh9zBDm9zxFSQt55D29odo3rJt4feoWRqn4U/tzicw==",
 			"funding": [
 				{
 					"type": "github",
@@ -4262,10 +4254,9 @@
 					"url": "https://opencollective.com/fastify"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"ajv": "^8.12.0",
-				"dotenv": "^16.4.5",
-				"dotenv-expand": "10.0.0"
+				"ajv": "^8.12.0"
 			}
 		},
 		"node_modules/env-schema/node_modules/ajv": {
@@ -5507,9 +5498,10 @@
 			}
 		},
 		"node_modules/lru-cache": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-			"integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+			"version": "11.2.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+			"integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
 			}
@@ -9290,9 +9282,9 @@
 			}
 		},
 		"node_modules/piscina": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.3.tgz",
-			"integrity": "sha512-0u3N7H4+hbr40KjuVn2uNhOcthu/9usKhnw5vT3J7ply79v3D3M8naI00el9Klcy16x557VsEkkUQaHCWFXC/g==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
+			"integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.x"

--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"@sinclair/typebox": "^0.34.41",
-		"env-schema": "^6.0.1",
-		"lru-cache": "^11.0.2",
-		"piscina": "^5.1.3"
+		"@sinclair/typebox": "^0.34.48",
+		"env-schema": "^7.0.0",
+		"lru-cache": "^11.2.5",
+		"piscina": "^5.1.4"
 	},
 	"devDependencies": {
 		"@aws-crypto/sha256-js": "^5.2.0",
@@ -66,8 +66,8 @@
 		"@fgiova/cjs-esm-ts-builder": "^1.2.0",
 		"@semantic-release/changelog": "^6.0.3",
 		"@semantic-release/git": "^10.0.1",
-		"@smithy/protocol-http": "^5.0.1",
-		"@smithy/signature-v4": "^5.0.1",
+		"@smithy/protocol-http": "^5.3.8",
+		"@smithy/signature-v4": "^5.3.8",
 		"@tsconfig/node20": "^20.1.4",
 		"@types/node": "^20.17.23",
 		"benchmark": "^2.1.4",

--- a/test-esm/indexESM.mjs
+++ b/test-esm/indexESM.mjs
@@ -19,9 +19,9 @@ test("Sign Request Worker", async (t) => {
 	});
 
 	await t.test("should sign request without body", async (t) => {
+		const signer = new Signer();
 		try {
 			const date = new Date("2000-01-01T00:00:00.000Z");
-			const signer = new Signer();
 			const request = await signer.request(
 				t.context.requestData,
 				"foo",
@@ -34,6 +34,8 @@ test("Sign Request Worker", async (t) => {
 			);
 		} catch (error) {
 			console.log(error);
+		} finally {
+			await signer.destroy();
 		}
 	});
 
@@ -54,6 +56,7 @@ test("Sign Request Worker", async (t) => {
 			request.headers["Authorization"],
 			"AWS4-HMAC-SHA256 Credential=foo/20000101/us-bar-1/foo/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=cf22a0befff359388f136b158f0b1b43db7b18d2ca65ce4112bc88a16815c4b6",
 		);
+		await signer.destroy();
 	});
 
 	await t.test(
@@ -75,6 +78,7 @@ test("Sign Request Worker", async (t) => {
 				request.headers["Authorization"],
 				"AWS4-HMAC-SHA256 Credential=foo/20000101/us-bar-1/foo-test-2/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=1becd5fd94ce1e82b68d98fa70a9c99b4b4668eec909cf2f41f482426ac44970",
 			);
+			await signer.destroy();
 		},
 	);
 
@@ -101,5 +105,6 @@ test("Sign Request Worker", async (t) => {
 		);
 		const sameSigner = SignerSingletonTwo.getSigner();
 		t.equal(signer, sameSigner);
+		await SignerSingleton.destroy();
 	});
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -20,9 +20,9 @@ test("Sign Request Worker", async (t) => {
 	});
 
 	await t.test("should sign request without body", async (t) => {
+		const signer = new Signer();
 		try {
 			const date = new Date("2000-01-01T00:00:00.000Z");
-			const signer = new Signer();
 			const request = await signer.request(
 				t.context.requestData,
 				"foo",
@@ -36,6 +36,8 @@ test("Sign Request Worker", async (t) => {
 			);
 		} catch (error) {
 			console.log(error);
+		} finally {
+			await signer.destroy();
 		}
 	});
 
@@ -57,6 +59,7 @@ test("Sign Request Worker", async (t) => {
 			request.headers?.["Authorization"],
 			"AWS4-HMAC-SHA256 Credential=foo/20000101/us-bar-1/foo/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=cf22a0befff359388f136b158f0b1b43db7b18d2ca65ce4112bc88a16815c4b6",
 		);
+		await signer.destroy();
 	});
 
 	await t.test(
@@ -79,6 +82,7 @@ test("Sign Request Worker", async (t) => {
 				request.headers?.["Authorization"],
 				"AWS4-HMAC-SHA256 Credential=foo/20000101/us-bar-1/foo-test-2/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=1becd5fd94ce1e82b68d98fa70a9c99b4b4668eec909cf2f41f482426ac44970",
 			);
+			await signer.destroy();
 		},
 	);
 
@@ -104,5 +108,6 @@ test("Sign Request Worker", async (t) => {
 		const { SignerSingleton: SignerSingletonTwo } = require("../src/index");
 		const sameSigner = SignerSingletonTwo.getSigner();
 		t.equal(signer, sameSigner);
+		await SignerSingleton.destroy();
 	});
 });


### PR DESCRIPTION
Add proper destroy/close methods to Signer and SignerSingleton. Fix benchmark crash by deferring signer cleanup to suite onComplete instead of individual benchmark onComplete, preventing AbortError from force-closing the Piscina pool with in-flight async tasks.