### PR TITLE
Optimize memory usage and performance under sustained load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@fgiova/aws-signature",
-	"version": "3.2.0",
+	"version": "4.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@fgiova/aws-signature",
-			"version": "3.2.0",
+			"version": "4.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@sinclair/typebox": "^0.34.48",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,16 +36,21 @@ export type SignerOptions = {
 	maxQueue?: number | "auto";
 	concurrentTasksPerWorker?: number;
 	resourceLimits?: ResourceLimits;
+	maxTasksBeforeRecycle?: number;
 };
 
 export class Signer {
-	private readonly worker: Piscina;
+	private worker: Piscina;
 	private readonly keyCache: LRUCache<string, Buffer>;
 	private readonly credentials: {
 		region: string;
 		accessKeyId: string;
 		secretAccessKey: string;
 	};
+	private readonly piscinaOptions: ConstructorParameters<typeof Piscina>[0];
+	private readonly maxTasksBeforeRecycle?: number;
+	private completedAtLastRecycle = 0;
+	private recycling?: Promise<void>;
 
 	cpuCount: number = (() => {
 		try {
@@ -64,6 +69,7 @@ export class Signer {
 			maxQueue,
 			concurrentTasksPerWorker,
 			resourceLimits,
+			maxTasksBeforeRecycle,
 			credentials: credentialsOptions,
 		} = options;
 
@@ -87,17 +93,38 @@ export class Signer {
 			ttl: 1000 * 60 * 60 * 24,
 		});
 
-		this.worker = new Piscina({
+		this.piscinaOptions = {
 			filename: path.resolve(__dirname, `./sign_worker.${runEnv.ext}`),
 			execArgv: runEnv.execArgv,
 			name: "generateKey",
 			minThreads: minThreads ?? Math.max(this.cpuCount / 2, 1),
 			maxThreads: maxThreads ?? this.cpuCount * 1.5,
-			idleTimeout,
+			idleTimeout: idleTimeout ?? 30_000,
 			maxQueue,
 			concurrentTasksPerWorker,
 			resourceLimits,
+		};
+		this.maxTasksBeforeRecycle = maxTasksBeforeRecycle;
+		this.worker = new Piscina(this.piscinaOptions);
+	}
+
+	private async recyclePool() {
+		if (this.recycling) return this.recycling;
+		const old = this.worker;
+		this.worker = new Piscina(this.piscinaOptions);
+		this.completedAtLastRecycle = 0;
+		this.recycling = old.close({ force: false }).finally(() => {
+			this.recycling = undefined;
 		});
+		return this.recycling;
+	}
+
+	private maybeTriggerRecycle() {
+		if (!this.maxTasksBeforeRecycle || this.recycling) return;
+		const delta = this.worker.completed - this.completedAtLastRecycle;
+		if (delta >= this.maxTasksBeforeRecycle) {
+			void this.recyclePool();
+		}
 	}
 
 	private millsToNextDay() {
@@ -135,14 +162,20 @@ export class Signer {
 				ttl: this.millsToNextDay(),
 			});
 		}
-		return (await this.worker.run(
+		const signedHeaders = (await this.worker.run(
 			{ credentials: requestCredentials, request, service, key, date },
 			{ name: "signRequest" },
-		)) as HttpRequest;
+		)) as Record<string, string>;
+		request.headers = { ...(request.headers ?? {}), ...signedHeaders };
+		this.maybeTriggerRecycle();
+		return request;
 	}
 
 	async destroy() {
 		this.keyCache.clear();
+		if (this.recycling) {
+			await this.recycling;
+		}
 		return this.worker.close({ force: true });
 	}
 }

--- a/src/sign_worker.ts
+++ b/src/sign_worker.ts
@@ -79,25 +79,27 @@ export function signRequest({
 	credentials: AwsCredentials;
 	key: Buffer;
 	date: Date;
-}) {
+}): Record<string, string> {
 	const { shortDate, longDate } = formatDate(date);
-	/* c8 ignore next 3 */
-	if (!request.headers) {
-		request.headers = {};
-	}
-	request.headers[AMZ_DATE_HEADER] = longDate;
-	request.headers[SHA256_HEADER] = getPayloadHash(request);
+	const payloadHash = getPayloadHash(request);
+	const headers = {
+		...(request.headers ?? {}),
+		[AMZ_DATE_HEADER]: longDate,
+		[SHA256_HEADER]: payloadHash,
+	};
+	const requestWithHeaders = { ...request, headers };
 	const scope = createScope(shortDate, service, credentials.region);
-	const canonicalHeaders = getCanonicalHeaders(request);
+	const canonicalHeaders = getCanonicalHeaders(requestWithHeaders);
 	const canonicalRequest = createCanonicalRequest(
-		request,
+		requestWithHeaders,
 		canonicalHeaders,
 		service.toLowerCase() === "s3",
 	);
 	const signature = authSignature(key, longDate, scope, canonicalRequest);
 
-	// biome-ignore lint/complexity/useLiteralKeys: leave as is
-	request.headers["Authorization"] =
-		`${ALGORITHM_IDENTIFIER} Credential=${credentials.accessKeyId}/${scope}, SignedHeaders=${getCanonicalHeaderList(canonicalHeaders)}, Signature=${signature}`;
-	return request;
+	return {
+		[AMZ_DATE_HEADER]: longDate,
+		[SHA256_HEADER]: payloadHash,
+		Authorization: `${ALGORITHM_IDENTIFIER} Credential=${credentials.accessKeyId}/${scope}, SignedHeaders=${getCanonicalHeaderList(canonicalHeaders)}, Signature=${signature}`,
+	};
 }

--- a/test/signRequest.ts
+++ b/test/signRequest.ts
@@ -31,7 +31,7 @@ test("Sign Request", async (t) => {
 			},
 			date,
 		});
-		const request = signRequest({
+		const signedHeaders = signRequest({
 			request: t.context.requestData,
 			service: "foo",
 			credentials: {
@@ -43,8 +43,7 @@ test("Sign Request", async (t) => {
 		});
 
 		t.same(
-			// biome-ignore lint/complexity/useLiteralKeys: leave as is
-			request.headers?.["Authorization"],
+			signedHeaders.Authorization,
 			"AWS4-HMAC-SHA256 Credential=foo/20000101/us-bar-1/foo/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=1e3b24fcfd7655c0c245d99ba7b6b5ca6174eab903ebfbda09ce457af062ad30",
 		);
 	});
@@ -59,7 +58,7 @@ test("Sign Request", async (t) => {
 			},
 			date,
 		});
-		const request = signRequest({
+		const signedHeaders = signRequest({
 			request: {
 				...t.context.requestData,
 				body: "It was the best of times, it was the worst of times",
@@ -74,9 +73,36 @@ test("Sign Request", async (t) => {
 		});
 
 		t.same(
-			// biome-ignore lint/complexity/useLiteralKeys: leave as is
-			request.headers?.["Authorization"],
+			signedHeaders.Authorization,
 			"AWS4-HMAC-SHA256 Credential=foo/20000101/us-bar-1/foo/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=cf22a0befff359388f136b158f0b1b43db7b18d2ca65ce4112bc88a16815c4b6",
 		);
+	});
+
+	await t.test("should sign request without headers", async (t) => {
+		const date = new Date("2000-01-01T00:00:00.000Z");
+		const key = generateKey({
+			service: "foo",
+			credentials: {
+				...credentials,
+				region: "us-bar-1",
+			},
+			date,
+		});
+		const signedHeaders = signRequest({
+			request: {
+				method: "POST",
+				path: "/",
+			},
+			service: "foo",
+			credentials: {
+				...credentials,
+				region: "us-bar-1",
+			},
+			key,
+			date,
+		});
+
+		t.match(signedHeaders.Authorization, /^AWS4-HMAC-SHA256 Credential=foo\//);
+		t.equal(signedHeaders["x-amz-date"], "20000101T000000Z");
 	});
 });


### PR DESCRIPTION
This pull request introduces a new mechanism for recycling the worker pool in the `Signer` class after a configurable number of tasks, improving resource management and stability. It also changes the `signRequest` function to return only the signed headers instead of mutating the request object directly, resulting in a cleaner and more predictable API. Corresponding updates have been made to tests to reflect these changes, and a new test has been added for requests without headers.

**Worker Pool Recycling Improvements:**

* Added a `maxTasksBeforeRecycle` option to `SignerOptions` and implemented logic in the `Signer` class to automatically recycle the Piscina worker pool after the specified number of tasks, preventing resource leaks and improving long-term stability. (`src/index.ts`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R39-R53) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R72) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L90-R127)
* Refactored the worker pool instantiation to store Piscina options and handle recycling logic, including proper cleanup in the `destroy` method. (`src/index.ts`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L90-R127) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L138-R178)

**API Changes to Signing Logic:**

* Updated `signRequest` to return a headers object with the necessary AWS signature headers instead of mutating the request in place, improving functional purity and making the API easier to use and test. (`src/sign_worker.ts`, `src/index.ts`) [[1]](diffhunk://#diff-9a9350b1749e84177e9d8516bd7870b5038ac5e2ef3e516b0355014a46042a4dL82-R104) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L138-R178)

**Test Suite Updates:**

* Updated tests to use the new return value from `signRequest` (headers object) and added a test case for signing requests that do not have headers, ensuring broader coverage. (`test/signRequest.ts`) [[1]](diffhunk://#diff-0e43ffb9b083688c493cf774f03b4dc3180e98fa125559f31c5fd6ef3d104029L34-R34) [[2]](diffhunk://#diff-0e43ffb9b083688c493cf774f03b4dc3180e98fa125559f31c5fd6ef3d104029L46-R46) [[3]](diffhunk://#diff-0e43ffb9b083688c493cf774f03b4dc3180e98fa125559f31c5fd6ef3d104029L62-R61) [[4]](diffhunk://#diff-0e43ffb9b083688c493cf774f03b4dc3180e98fa125559f31c5fd6ef3d104029L77-R107)